### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Floating Lable project is in initial mode, where a few customization is provided
         floatview:textColor="@color/blue"
         floatview:textTypeface="some_custome_font.ttf"/>
 ```
-##Features 
+## Features 
 * [Float Hint Text](#float-hint-text)
 * [Float Hint Text Color](#float-hint-text-color)
 * [Float Hint Text Style](#float-hint-text-style)
@@ -38,77 +38,77 @@ Floating Lable project is in initial mode, where a few customization is provided
 * [Actual Text As Password](#actual-text-as-password)
 
 
-###Float Hint Text
+### Float Hint Text
 * Specifies the text for float hint label
 ```Android
 	floatview:floatHintText="@string/app_name"
 ```
-###Float Hint Text Color
+### Float Hint Text Color
 * Specifies text color for float hint label both for focused mode and unfocused mode
 ```Android
 	floatview:floatHintTextColorFocused="@color/blue"
         floatview:floatHintTextColorUnFocused="@color/green"
 ```
-###Float Hint Text Style
+### Float Hint Text Style
 * Specifies the text style, bold,normal,italic
 ```Android
 	floatview:floatHintTextStyle="bold"
 ```
-###Float Hint Text Gravity
+### Float Hint Text Gravity
 * Specifies gravity of text left,right,top,bottom
 ```Android
 	floatview:floatHintTextGravity="right"
 ```
-###Float Hint Text Size
+### Float Hint Text Size
 * Specifies text size
 ```Android
 	floatview:floatHintTextSize="20"
 ```
-###Float Hint Text Custom Typeface
+### Float Hint Text Custom Typeface
 * Specifies custom font. (It has to be in to the assets folder e.g. /assets/some_font.ttf)
 ```Android
 	floatview:floatHintTextTypeface="Ithornet.ttf"
 ```
-###Float Hint Text Background
+### Float Hint Text Background
 * Specifies custom background. You can specify both color and drawable.
 ```Android
 	floatview:floatHintTextBackground="@drawable/label_bg"
 ```
-###Actual Text
+### Actual Text
 * Specifies the text for editable text box
 ```Android
 	floatview:text="Label 1"
 ```
-###Actual Text Color
+### Actual Text Color
 * Specifies text color for editable text box
 ```Android
 	floatview:textColor="@color/red"
 ```
-###Actual Text Style
+### Actual Text Style
 * Specifies the text style, bold,normal,italic
 ```Android
 	floatview:textStyle="bold"
 ```
-###Actual Text Gravity
+### Actual Text Gravity
 * Specifies gravity of text left,right,top,bottom
 ```Android
 	floatview:textGravity="right"
 ```
-###Actual Text Size
+### Actual Text Size
 * Specifies text size
 ```Android
 	floatview:textSize="20"
 ```
-###Actual Text Custom Typeface
+### Actual Text Custom Typeface
 * Specifies custom font. (It has to be in to the assets folder e.g. /assets/some_font.ttf)
 ```Android
 	floatview:textTypeface="Ithornet.ttf"
 ```
-###Actual Text Background
+### Actual Text Background
 ```Android
 	floatview:textBackground="@drawable/edt_bg"
 ```
-###Actual Text As Password
+### Actual Text As Password
 ```Android
 	floatview:isPassword="true"
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
